### PR TITLE
Updating CMakeLists and source includes to point to new apriltags_cpp package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 find_package(OpenCV REQUIRED)
 find_package(Eigen REQUIRED)
+find_package(apriltags_cpp REQUIRED)
 
 # Import the yaml-cpp libraries.
 include(FindPkgConfig)
@@ -43,41 +44,13 @@ catkin_package(
 # CGAL requires that -frounding-math be set.
 add_definitions(-frounding-math)
 
-# Download the external Swatbotics repository.
-include(ExternalProject)
-ExternalProject_Add(apriltags_swatbotics_EXTERNAL
-    GIT_REPOSITORY https://github.com/personalrobotics/apriltags-cpp
-    INSTALL_COMMAND ""
-    BUILD_COMMAND "make" # I don't know why this works...
-    CMAKE_ARGS -DCMAKE_CXX_FLAGS=-frounding-math -DBUILD_SHARED_LIBS:BOOL=ON
-)
-
-# Recover project paths for additional settings.
-ExternalProject_Get_Property(apriltags_swatbotics_EXTERNAL
-  SOURCE_DIR BINARY_DIR INSTALL_DIR)
-set(apriltags_swatbotics_INCLUDE_DIRS
-  "${SOURCE_DIR}"
-)
-set(apriltags_swatbotics_LIBRARIES
-  "${BINARY_DIR}/libapriltags.so"
-)
-
-# Tell CMake that the external project generated a library so we
-# can add dependencies here instead of later.
-add_library(apriltags_swatbotics UNKNOWN IMPORTED)
-set_property(TARGET apriltags_swatbotics
-  PROPERTY IMPORTED_LOCATION
-  ${apriltags_swatbotics_LIBRARIES}
-)
-add_dependencies(apriltags_swatbotics apriltags_swatbotics_EXTERNAL)
-
 include_directories(
     include/
     ${catkin_INCLUDE_DIRS}
     ${Eigen_INCLUDE_DIRS}
     ${OpenCV_INCLUDE_DIRS}
     ${Yaml_INCLUDE_DIRS}
-    ${apriltags_swatbotics_INCLUDE_DIRS}
+    ${apriltags_cpp_INCLUDE_DIRS}
 )
 
 add_executable(apriltags src/apriltags.cpp)
@@ -85,13 +58,10 @@ target_link_libraries(apriltags ${catkin_LIBRARIES})
 target_link_libraries(apriltags ${Eigen_LIBRARIES})
 target_link_libraries(apriltags ${OpenCV_LIBRARIES})
 target_link_libraries(apriltags ${Yaml_LIBRARIES})
-target_link_libraries(apriltags apriltags_swatbotics)
+target_link_libraries(apriltags ${apriltags_cpp_LIBRARIES})
 add_dependencies(apriltags ${PROJECT_NAME}_gencpp)
 
 install(TARGETS apriltags
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION} 
 )
 
-install(FILES ${apriltags_swatbotics_LIBRARIES}
-  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-)

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>git</build_depend>
   <build_depend>message_generation</build_depend>
+  <depend>apriltags_cpp</depend>
   <depend>cgal</depend>
   <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>

--- a/src/apriltags.cpp
+++ b/src/apriltags.cpp
@@ -37,9 +37,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <opencv/highgui.h>
 #include <cv_bridge/cv_bridge.h>
 
-#include <src/TagDetector.h>
-#include <src/TagDetection.h>
-#include <src/TagFamily.h>
+#include <apriltags_cpp/TagDetector.h>
+#include <apriltags_cpp/TagDetection.h>
+#include <apriltags_cpp/TagFamily.h>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>


### PR DESCRIPTION
I made the CMakeLists.txt stop downloading the apriltags-cpp library (yay!) and instead it now refers to the separate package as a dependency.

@locusrobotics/robot-software-team 