### PR TITLE
Removed cout on tag detection.

### DIFF
--- a/src/apriltags.cpp
+++ b/src/apriltags.cpp
@@ -324,7 +324,6 @@ void ImageCallback(const sensor_msgs::ImageConstPtr& msg)
         Eigen::Quaternion<double> q(R);
         
         double tag_size = GetTagSize(detections[i].id);
-        cout << tag_size << " " << detections[i].id << endl;
         
         // Fill in MarkerArray msg
         visualization_msgs::Marker marker_transform;


### PR DESCRIPTION
This stops apriltags from filling up the log, especially when multiple tags are present. Users can just subscribe to the detections topic instead.